### PR TITLE
Fix misspelling of html in layout.html.haml

### DIFF
--- a/lib/generators/haml/mailer/templates/layout.html.haml
+++ b/lib/generators/haml/mailer/templates/layout.html.haml
@@ -1,3 +1,3 @@
-%hmtl
+%html
   %body
     = yield


### PR DESCRIPTION
or it will be malformed in HTML email.
